### PR TITLE
Fuzzy detection of partial XSS reflections enabled, new detect_xss() method, docstrings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ ghostdriver.log
 /payloads/*
 /logs/*
 /screenshots/*
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Partial XSS reflections will be logged in a separate text file ending with "_par
 
 You also must have PhantomJS installed and configured in order for the tool to run in its default mode. See the next section for more details on this.
 
-**There may be a noticeable slowdown of the tool when it is being used in a virtual machine such as VirtualBox.** For best performance, use Shuriken on a native machine, I am currently looking to address this virtual machine slowdown in a future update.
+**There may be a noticeable slowdown of the tool when it is being used in a virtual machine such as VirtualBox.** For best performance, use Shuriken on a native machine. I am currently looking to address this virtual machine slowdown in a future update.
 
 ## Third party libraries and dependencies
 This tool depends on the proper configuration and installation of the following:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ To test a list of payloads against a target URL, specify where the payloads will
 
 `python shuriken_xss.py -u "http://example.com/target.php?name={xss}" -p "xss-payload-list.txt"`
 
+### Taking screenshots
+
 If you would like to screenshot and save all reflected XSS payloads, use the *-s* or *--screen* flag with a name for the screenshot images and enter:
 
 `python shuriken_xss.py -s ExampleTarget -u "http://example.com/target.php?name={xss}" -p "xss-payload-list.txt"`
@@ -38,13 +40,23 @@ To wait a specific amount of time in between requests, use the *-t* flag with th
 
 `python shuriken_xss.py -t 1.5 -u "http://example.com/target.php?name={xss}" -p "xss-payload-list.txt"`
 
+### Fuzzy XSS payload detection
+
 To enable partial or fuzzy detection of XSS payloads in HTML source code, use the *-f* or *--fuzzy* flag with the level of detection you want to log. For example, the following command will only log XSS payload reflections that have a 75% matching score or above in the HTML source code returned:
 
 `python shuriken_xss.py -f 75 -u "http://example.com/target.php?name={xss}" -p "xss-payload-list.txt"`
 
-The default matching score supplied is 50% and will be applied when a flag with no number is given (e.g. -f or --fuzzy). Partial detection is applied through the use of SeatGeek's [FuzzyWuzzy](https://github.com/seatgeek/fuzzywuzzy) Python library `token_set_ratio()` method and additional information regarding this library can be found [here](http://chairnerd.seatgeek.com/fuzzywuzzy-fuzzy-string-matching-in-python/). Partial XSS reflections will be logged in a separate file ending with "_partials.txt".
+The default matching score supplied is 50% and will be applied when a flag with no number is given (e.g. -f or --fuzzy): 
+
+`python shuriken_xss.py -f -u "http://example.com/target.php?name={xss}" -p "xss-payload-list.txt"`
+
+Partial detection is applied through the use of SeatGeek's [FuzzyWuzzy](https://github.com/seatgeek/fuzzywuzzy) Python library `token_set_ratio()` method and additional information regarding this library can be found [here](http://chairnerd.seatgeek.com/fuzzywuzzy-fuzzy-string-matching-in-python/). Partial XSS reflections will be logged in a separate file ending with "_partials.txt".
+
+### Misc. usage notes
 
 **You must specify a payload and URL**, if you don't then you'll get an error. For an example payload to test with, check out this list of [common XSS payloads](https://github.com/foospidy/payloads/blob/master/owasp/fuzzing_code_database/xss/common.txt).
+
+You also must have PhantomJS installed and configured in order for the tool to run in its default mode. See the next section for more details on this.
 
 ## Third party libraries and dependencies
 This tool depends on the proper configuration and installation of the following:

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ To test a list of payloads against a target URL, specify where the payloads will
 
 `python shuriken_xss.py -u "http://example.com/target.php?name={xss}" -p "xss-payload-list.txt"`
 
-If you would like to screenshot and save all reflected XSS payloads, use the *--screen* flag with a name for the screenshot images and enter:
+If you would like to screenshot and save all reflected XSS payloads, use the *-s* or *--screen* flag with a name for the screenshot images and enter:
 
-`python shuriken_xss.py -u "http://example.com/target.php?name={xss}" -p "xss-payload-list.txt" --screen ExampleTarget`
+`python shuriken_xss.py -s ExampleTarget -u "http://example.com/target.php?name={xss}" -p "xss-payload-list.txt"`
 
 To wait a specific amount of time in between requests, use the *-t* flag with the amount of time to wait in seconds and enter:
 
-`python shuriken_xss.py -u "http://example.com/target.php?name={xss}" -p "xss-payload-list.txt" -t 1.5`
+`python shuriken_xss.py -t 1.5 -u "http://example.com/target.php?name={xss}" -p "xss-payload-list.txt"`
 
 To enable partial or fuzzy detection of XSS payloads in HTML source code, use the *-f* or *--fuzzy* flag with the level of detection you want to log. For example, the following command will only log XSS payload reflections that have a 75% matching score or above in the HTML source code returned:
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ Shuriken works with [Python](http://www.python.org/download/) **2.7.x** on any p
 ## Features
 - Easily specify where in a URL the payload should be injected with the "{xss}" string.
 - Quickly change payload lists.
-- Take screenshots of successful XSS hits.
+- Take screenshots of successful XSS payloads.
 - Save logs of reflected XSS payloads.
+- Use fuzzy detection to log partial XSS reflections.
 
 ## Usage
 To get a list of options and switches, enter:
@@ -37,6 +38,12 @@ To wait a specific amount of time in between requests, use the *-t* flag with th
 
 `python shuriken_xss.py -u "http://example.com/target.php?name={xss}" -p "xss-payload-list.txt" -t 1.5`
 
+To enable partial or fuzzy detection of XSS payloads in HTML source code, use the *-f* or *--fuzzy* flag with the level of detection you want to log. For example, the following command will only log XSS payload reflections that have a 75% matching score or above in the HTML source code returned:
+
+`python shuriken_xss.py -f 75 -u "http://example.com/target.php?name={xss}" -p "xss-payload-list.txt"`
+
+The default matching score supplied is 50% and will be applied when a flag with no number is given (e.g. -f or --fuzzy). Partial detection is applied through the use of SeatGeek's [FuzzyWuzzy](https://github.com/seatgeek/fuzzywuzzy) Python library `token_set_ratio()` method and additional information regarding this library can be found [here](http://chairnerd.seatgeek.com/fuzzywuzzy-fuzzy-string-matching-in-python/). Partial XSS reflections will be logged in a separate file ending with "_partials.txt".
+
 **You must specify a payload and URL**, if you don't then you'll get an error. For an example payload to test with, check out this list of [common XSS payloads](https://github.com/foospidy/payloads/blob/master/owasp/fuzzing_code_database/xss/common.txt).
 
 ## Third party libraries and dependencies
@@ -45,6 +52,8 @@ This tool depends on the proper configuration and installation of the following:
 - [Splinter](https://splinter.readthedocs.io/en/latest/install.html) - Python library allowing use of a headless web browser for testing.
 - [PhantomJS](http://phantomjs.org/download.html) - Headless WebKit browser used by Splinter for testing.
 - [Selenium 2.0](http://www.seleniumhq.org/docs/03_webdriver.jsp) - WebDriver required by PhantomJS browser.
+- [FuzzyWuzzy](https://github.com/seatgeek/fuzzywuzzy) - Partial XSS logging using fuzzy detection methods.
+- [python-Levenshtein](https://pypi.python.org/pypi/python-Levenshtein/0.12.0) - Python extension for computing string edit distances and similarities. Allows faster fuzzy detection from the FuzzyWuzzy library.
 
 Python dependencies can be installed using pip: `pip install -r requirements.txt`. Use your platform-specific mechanism to install PhatomJS (e.g. `brew` on OSX, `apt-get` on Debian or Ubuntu, etc). 
 

--- a/README.md
+++ b/README.md
@@ -54,11 +54,13 @@ Partial detection is applied through the use of SeatGeek's [FuzzyWuzzy](https://
 
 Partial XSS reflections will be logged in a separate text file ending with "_partials.txt".
 
-### Misc. usage notes
+### Misc. usage and performance notes
 
 **You must specify a payload and URL**, if you don't then you'll get an error. For an example payload to test with, check out this list of [common XSS payloads](https://github.com/foospidy/payloads/blob/master/owasp/fuzzing_code_database/xss/common.txt).
 
 You also must have PhantomJS installed and configured in order for the tool to run in its default mode. See the next section for more details on this.
+
+**There may be a noticeable slowdown of the tool when it is being used in a virtual machine such as VirtualBox.** For best performance, use Shuriken on a native machine, I am currently looking to address this virtual machine slowdown in a future update.
 
 ## Third party libraries and dependencies
 This tool depends on the proper configuration and installation of the following:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ The default matching score supplied is 50% and will be applied when a flag with 
 
 `python shuriken_xss.py -f -u "http://example.com/target.php?name={xss}" -p "xss-payload-list.txt"`
 
-Partial detection is applied through the use of SeatGeek's [FuzzyWuzzy](https://github.com/seatgeek/fuzzywuzzy) Python library `token_set_ratio()` method and additional information regarding this library can be found [here](http://chairnerd.seatgeek.com/fuzzywuzzy-fuzzy-string-matching-in-python/). Partial XSS reflections will be logged in a separate file ending with "_partials.txt".
+Partial detection is applied through the use of SeatGeek's [FuzzyWuzzy](https://github.com/seatgeek/fuzzywuzzy) Python library `token_set_ratio()` method and additional information regarding this library can be found [here](http://chairnerd.seatgeek.com/fuzzywuzzy-fuzzy-string-matching-in-python/). 
+
+Partial XSS reflections will be logged in a separate text file ending with "_partials.txt".
 
 ### Misc. usage notes
 

--- a/README.md
+++ b/README.md
@@ -75,11 +75,13 @@ If you would prefer that this tool ***use a different browser for testing***, yo
 
 ## Screenshots
 **Basic usage**
-![screen_1](https://i.imgur.com/91dGSfS.png "Shuriken Screenshot #1")
+![screen_1](https://i.imgur.com/LzPpTsh.png "Shuriken Screenshot #1")
 
+**With *-s* or *--screen* option to record screenshots and *-t* option to delay requests by specific amount**
+![screen_2](https://i.imgur.com/EjYdAGD.png "Shuriken Screenshot #2")
 
-**With *--screen* option to record screenshots and *-t* option to delay requests by specific amount**
-![screen_2](https://i.imgur.com/md9j82N.png "Shuriken Screenshot #2")
+**With *-f* or *--fuzzy* option to fuzzy detect and log partial XSS payload reflections**
+![screen_3](https://i.imgur.com/9lwcFxl.png "Shuriken Screenshot #3")
 
 ## Legal
 Shuriken was derived from the excellent XSS command line tool by Faizan Ahmad, called [XssPy](https://github.com/faizann24/XssPy). The Shuriken XSS tool is under an MIT license, you can read it [here](https://github.com/shogunlab/shuriken/blob/master/LICENSE.md).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 splinter==0.7.5
 selenium==3.4.3
+fuzzywuzzy==0.15.1
+python-Levenshtein==0.12.0

--- a/shuriken_xss.py
+++ b/shuriken_xss.py
@@ -67,6 +67,7 @@ class Shuriken:
                 "XSS vulnerabilities were detected!" + \
                 Color.END
             self.log_file(self.xss_links)
+        # There were partials detected by fuzzy detection
         elif self.xss_partials:
             print Color.YELLOW + \
                 "Partial XSS vulnerabilities were detected!" + \
@@ -194,17 +195,20 @@ class Shuriken:
             target_name = raw_input("Please enter the target name > ")
             # Check if logs directory exists, if not then create it
             self.make_sure_path_exists("logs")
-            # Save log file to directory
+            # Set file name
             file_name = "logs/" + target_name + "_" + \
                 datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
-            with open(file_name + ".txt", 'w') as link_file:
-                for link in link_list:
-                    link_file.write(link)
-                    link_file.write("\n")
-                # Add metadata about what payload file was used
-                link_file.write("\n*** Created from the payload file >>> " +
-                                self.user_args.PAYLOADS_LIST)
-                link_file.close()
+            # Save log file to directory if XSS links is populated
+            if self.xss_links:
+                with open(file_name + ".txt", 'w') as link_file:
+                    for link in link_list:
+                        link_file.write(link)
+                        link_file.write("\n")
+                    # Add metadata about what payload file was used
+                    link_file.write(
+                        "\n*** Created from the payload file >>> " +
+                        self.user_args.PAYLOADS_LIST)
+                    link_file.close()
             # If the user enabled fuzzy detection, log partial results
             if (self.user_args.FUZZY_DETECTION):
                 with open(file_name + "_partials.txt", 'w') as partial_file:
@@ -214,8 +218,7 @@ class Shuriken:
                     # Add metadata about what payload file was used
                     partial_file.write(
                         "\n*** Created from the payload file >>> " +
-                        self.user_args.PAYLOADS_LIST
-                    )
+                        self.user_args.PAYLOADS_LIST)
                     partial_file.close()
             print "\nFile successfully saved as: " + \
                 Color.BLUE + file_name + Color.END

--- a/shuriken_xss.py
+++ b/shuriken_xss.py
@@ -247,10 +247,10 @@ class Shuriken:
             '-t', action='store', dest='REQUEST_DELAY',
             help='Amount of time (in seconds) to delay between requests.')
         parser.add_argument(
-            '--screen', action='store', dest='SCREENSHOT_NAME',
+            '-s', '--screen', action='store', dest='SCREENSHOT_NAME',
             help='Enable screenshots of XSS hits.')
         parser.add_argument(
-            '-f', "--fuzzy", action='store', dest='FUZZY_DETECTION', type=int,
+            '-f', '--fuzzy', action='store', dest='FUZZY_DETECTION', type=int,
             const=50, nargs="?",
             help='Fuzzy detection rate of XSS [0 to 100 match] (default=50).')
 

--- a/shuriken_xss.py
+++ b/shuriken_xss.py
@@ -1,6 +1,5 @@
 # !/usr/bin/env python
-"""Set environment for Python code."""
-
+"""Set environment."""
 
 import argparse
 import datetime

--- a/shuriken_xss.py
+++ b/shuriken_xss.py
@@ -1,5 +1,6 @@
 # !/usr/bin/env python
-# -*- coding: utf-8 -*-
+"""Set environment for Python code."""
+
 
 import argparse
 import datetime
@@ -12,7 +13,8 @@ from splinter import Browser
 
 
 class Color:
-    # Use colors to make command line output prettier
+    """Use colors to make command line output prettier."""
+
     RED = '\033[91m'
     GREEN = '\033[92m'
     YELLOW = '\033[93m'
@@ -21,8 +23,10 @@ class Color:
 
 
 class Shuriken:
+    """Object for testing lists of XSS payloads."""
 
     def __init__(self):
+        """Initiate object with default encoding and other required data."""
         # Expect some weird characters from fuzz lists, make encoding UTF-8
         reload(sys)
         sys.setdefaultencoding('utf8')
@@ -40,6 +44,7 @@ class Shuriken:
         self.browser = Browser("phantomjs")
 
     def main(self):
+        """Call functions to inject XSS and test for vulnerabilities."""
         # Print out a welcome message
         print "\n"
         print "=" * 34 + Color.YELLOW + "\nWelcome to the" + Color.RED + \
@@ -66,6 +71,7 @@ class Shuriken:
             print "\n"
 
     def make_sure_path_exists(self, path):
+        """Ensure that file path exists before writing."""
         try:
             os.makedirs(path)
         except OSError as exception:
@@ -74,7 +80,7 @@ class Shuriken:
 
     def inject_payload(self, payload, link, request_delay,
                        user_screenshot_name):
-        # Visit user supplied link with injected payload
+        """Inject XSS payload string from user supplied payload list."""
         browser = self.browser
 
         # Let user specify where in the URL fuzz values should be injected
@@ -104,7 +110,7 @@ class Shuriken:
 
     def detect_xss(self, payload, browser_object, user_screenshot_name,
                    injected_link):
-        # Check to see if payload was reflected in HTML source
+        """Check the HTML source to determine if XSS payload was reflected."""
         if payload in browser_object.html:
             print Color.GREEN + "\n[+] Potential XSS vulnerability found:" + \
                 Color.END
@@ -122,6 +128,7 @@ class Shuriken:
                 Color.RED + injected_link + Color.END
 
     def take_screenshot(self, user_screenshot_name, browser_object):
+        """Take a screenshot of the page in the browser object."""
         # Check if screenshots directory exists, if not then create it
         self.make_sure_path_exists("screenshots")
         screenshot_file_name = "screenshots/" + \
@@ -135,6 +142,7 @@ class Shuriken:
 
     def test_xss(self, payloads_param, link, request_delay,
                  user_screenshot_name):
+        """Load string from payload list and call function to inject it."""
         # If the user added time delay, show them what it is set to.
         if request_delay is not None:
             print Color.YELLOW + "\n[!] Request delay is set to [" + \
@@ -152,6 +160,7 @@ class Shuriken:
                                 user_screenshot_name)
 
     def log_file(self, link_list):
+        """Log successful XSS payload reflections to file."""
         # Prompt the user to confirm log file, if yes, log XSS hits
         log_confirm = raw_input(
             "\nWould you like to save these results? [y/n] > ")
@@ -179,7 +188,7 @@ class Shuriken:
             print "\n"
 
     def parse_args(self):
-        # Parse arguments from the user sent on command line
+        """Parse arguments from the user sent on command line."""
         parser = argparse.ArgumentParser()
         parser.add_argument(
             '-u', action='store', dest='URL',

--- a/shuriken_xss.py
+++ b/shuriken_xss.py
@@ -121,9 +121,16 @@ class Shuriken:
     def detect_xss(self, payload, browser_object, user_screenshot_name,
                    injected_link):
         """Check the HTML source to determine if XSS payload was reflected."""
-        # Set up variables for fuzzy detection and scoring
+        # If fuzzy detection chosen, evaluate partial reflection of XSS
+        # by tokenizing the HTML source and detecting parts of the payload
+        # and source common to both.
+        #
+        # Other methods of scoring include fuzz.ratio(), fuzz.partial_ratio()
+        # and fuzz.token_sort_ratio()
         partial_score = fuzz.token_set_ratio(
             payload.lower(), browser_object.html.lower())
+        # Set the level of detection asked for by the user, e.g. Only detect
+        # matches with score higher than 50% fuzzy detection
         fuzzy_level = self.user_args.FUZZY_DETECTION
 
         if payload.lower() in browser_object.html.lower():

--- a/shuriken_xss.py
+++ b/shuriken_xss.py
@@ -252,7 +252,7 @@ class Shuriken:
         parser.add_argument(
             '-f', "--fuzzy", action='store', dest='FUZZY_DETECTION', type=int,
             const=50, nargs="?",
-            help='Fuzzy detection rate of XSS [0 to 100% match] (default=50).')
+            help='Fuzzy detection rate of XSS [0 to 100 match] (default=50).')
 
         arguments = parser.parse_args()
 

--- a/shuriken_xss.py
+++ b/shuriken_xss.py
@@ -52,8 +52,7 @@ class Shuriken:
                       self.user_args.SCREENSHOT_NAME)
         print Color.GREEN + "\n=== Testing complete! ===\n" + Color.END
 
-        # If the test found possible XSS vulnerabilities, ask if we should
-        # log
+        # If the test found possible XSS vulnerabilities, ask if we should log
         if self.xss_links:
             print Color.YELLOW + \
                 "Potential XSS vulnerabilities were detected!" + \
@@ -102,15 +101,17 @@ class Shuriken:
         # if so, take screenshot depending on user flag
         self.detect_xss(payload, browser, screenshot_target, injected_link)
     
-    def detect_xss(self, payload, browser_object, screenshot_target, injected_link):
+    def detect_xss(self, payload, browser_object, user_screenshot_name, injected_link):
         # Check to see if payload was reflected in HTML source
         if payload in browser_object.html:
             print Color.GREEN + "\n[+] Potential XSS vulnerability found:" + \
                 Color.END
+
             # If user set the --screen flag to target, capture screenshot of
             # payload
-            if screenshot_target is not None:
-                self.take_screenshot(screenshot_target, browser_object)
+            if user_screenshot_name is not None:
+                self.take_screenshot(user_screenshot_name, browser_object)
+
             # Add link to list of all positive XSS hits
             self.xss_links.append(injected_link)
             print Color.BLUE + injected_link + Color.END
@@ -118,11 +119,11 @@ class Shuriken:
             print Color.YELLOW + "\n[+] Tested, but no XSS found at: \n" + \
                 Color.RED + injected_link + Color.END
     
-    def take_screenshot(self, screenshot_target, browser_object):
+    def take_screenshot(self, screenshot_target_name, browser_object):
         # Check if screenshots directory exists, if not then create it
         self.make_sure_path_exists("screenshots")
         screenshot_file_name = "screenshots/" + \
-            screenshot_target + "_" + \
+            screenshot_target_name + "_" + \
             datetime.datetime.now().strftime("%Y%m%d-%H%M%S") + \
             "_" + self.screen_index + ".png"
         # Save screenshot to directory

--- a/shuriken_xss.py
+++ b/shuriken_xss.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+# !/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import argparse
@@ -97,11 +97,13 @@ class Shuriken:
         # linked to line nums in log
         self.screen_index = str(len(self.xss_links) + 1)
 
-        # Check to see if payload was reflected in HTML source, 
+        # Check to see if payload was reflected in HTML source,
         # if so, take screenshot depending on user flag
         self.detect_xss(payload, browser, screenshot_target, injected_link)
-    
-    def detect_xss(self, payload, browser_object, user_screenshot_name, injected_link):
+
+    def detect_xss(self, payload, browser_object,
+                   user_screenshot_name,
+                   injected_link):
         # Check to see if payload was reflected in HTML source
         if payload in browser_object.html:
             print Color.GREEN + "\n[+] Potential XSS vulnerability found:" + \
@@ -118,7 +120,7 @@ class Shuriken:
         else:
             print Color.YELLOW + "\n[+] Tested, but no XSS found at: \n" + \
                 Color.RED + injected_link + Color.END
-    
+
     def take_screenshot(self, screenshot_target_name, browser_object):
         # Check if screenshots directory exists, if not then create it
         self.make_sure_path_exists("screenshots")
@@ -145,8 +147,7 @@ class Shuriken:
                 line = line.strip()
                 payloads.append(line)
         for item in payloads:
-            self.inject_payload(item, link, request_delay,
-                                      screenshot_target)
+            self.inject_payload(item, link, request_delay, screenshot_target)
 
     def log_file(self, link_list):
         # Prompt the user to confirm log file, if yes, log XSS hits
@@ -166,7 +167,7 @@ class Shuriken:
                     link_file.write("\n")
                 # Add metadata about what payload file was used
                 link_file.write("\n*** Created from the payload file >>> " +
-                           self.user_args.PAYLOADS_LIST)
+                                self.user_args.PAYLOADS_LIST)
                 link_file.close()
             print "\nFile successfully saved as: " + \
                 Color.BLUE + file_name + Color.END

--- a/shuriken_xss.py
+++ b/shuriken_xss.py
@@ -120,9 +120,9 @@ class Shuriken:
     def detect_xss(self, payload, browser_object, user_screenshot_name,
                    injected_link):
         """Check the HTML source to determine if XSS payload was reflected."""
+        # Set up variables for fuzzy detection and scoring
         partial_score = fuzz.token_set_ratio(
             payload.lower(), browser_object.html.lower())
-
         fuzzy_level = self.user_args.FUZZY_DETECTION
 
         if payload.lower() in browser_object.html.lower():
@@ -138,6 +138,8 @@ class Shuriken:
             # Add link to list of all positive XSS hits
             self.xss_links.append(injected_link)
             print Color.BLUE + injected_link + Color.END
+        # If user enabled fuzzy detection and partial score was larger than
+        # fuzz level, add it to partials list and print results
         elif fuzzy_level and (partial_score >= fuzzy_level):
             print Color.YELLOW + \
                 "\n[-] Partial XSS vulnerability found:" + Color.END

--- a/shuriken_xss.py
+++ b/shuriken_xss.py
@@ -72,7 +72,8 @@ class Shuriken:
             if exception.errno != errno.EEXIST:
                 raise
 
-    def inject_payload(self, payload, link, request_delay, screenshot_target):
+    def inject_payload(self, payload, link, request_delay,
+                       user_screenshot_name):
         # Visit user supplied link with injected payload
         browser = self.browser
 
@@ -99,10 +100,9 @@ class Shuriken:
 
         # Check to see if payload was reflected in HTML source,
         # if so, take screenshot depending on user flag
-        self.detect_xss(payload, browser, screenshot_target, injected_link)
+        self.detect_xss(payload, browser, user_screenshot_name, injected_link)
 
-    def detect_xss(self, payload, browser_object,
-                   user_screenshot_name,
+    def detect_xss(self, payload, browser_object, user_screenshot_name,
                    injected_link):
         # Check to see if payload was reflected in HTML source
         if payload in browser_object.html:
@@ -121,11 +121,11 @@ class Shuriken:
             print Color.YELLOW + "\n[+] Tested, but no XSS found at: \n" + \
                 Color.RED + injected_link + Color.END
 
-    def take_screenshot(self, screenshot_target_name, browser_object):
+    def take_screenshot(self, user_screenshot_name, browser_object):
         # Check if screenshots directory exists, if not then create it
         self.make_sure_path_exists("screenshots")
         screenshot_file_name = "screenshots/" + \
-            screenshot_target_name + "_" + \
+            user_screenshot_name + "_" + \
             datetime.datetime.now().strftime("%Y%m%d-%H%M%S") + \
             "_" + self.screen_index + ".png"
         # Save screenshot to directory
@@ -133,7 +133,8 @@ class Shuriken:
         print Color.YELLOW + "Screenshot saved: " + \
             screenshot_file_name + Color.END
 
-    def test_xss(self, payloads_param, link, request_delay, screenshot_target):
+    def test_xss(self, payloads_param, link, request_delay,
+                 user_screenshot_name):
         # If the user added time delay, show them what it is set to.
         if request_delay is not None:
             print Color.YELLOW + "\n[!] Request delay is set to [" + \
@@ -147,7 +148,8 @@ class Shuriken:
                 line = line.strip()
                 payloads.append(line)
         for item in payloads:
-            self.inject_payload(item, link, request_delay, screenshot_target)
+            self.inject_payload(item, link, request_delay,
+                                user_screenshot_name)
 
     def log_file(self, link_list):
         # Prompt the user to confirm log file, if yes, log XSS hits

--- a/shuriken_xss.py
+++ b/shuriken_xss.py
@@ -1,5 +1,5 @@
 # !/usr/bin/env python
-"""Set environment."""
+"""Set Python environment."""
 
 import argparse
 import datetime
@@ -110,7 +110,7 @@ class Shuriken:
     def detect_xss(self, payload, browser_object, user_screenshot_name,
                    injected_link):
         """Check the HTML source to determine if XSS payload was reflected."""
-        if payload in browser_object.html:
+        if payload.lower() in browser_object.html.lower():
             print Color.GREEN + "\n[+] Potential XSS vulnerability found:" + \
                 Color.END
 


### PR DESCRIPTION
Added -f or --fuzzy flag to enable fuzzy detection of partial XSS reflections in HTML source code. Additional changes include a new detect_xss() method to allow easier improvements to this feature in the future as well as docstrings. A better method of scoring partial matches using fuzzy detection probably exists, but this is a decent first step. Flag is optional so users who are not interested in this feature should not be impacted by these changes.